### PR TITLE
2.4.0: improve performance

### DIFF
--- a/sim_core/sim_api_core.js
+++ b/sim_core/sim_api_core.js
@@ -145,16 +145,9 @@
 
         function simcore_action_ui ( component_name, detail_id, action_name )
         {
-            var sim_components = simhw_sim_components() ;
-
-            if (typeof sim_components[component_name].details_ui === "undefined") {
-                return simcore_do_nothing_handler ;
-            }
-            if (typeof sim_components[component_name].details_ui[detail_id][action_name] === "undefined") {
-                return simcore_do_nothing_handler ;
-            }
-
-            return sim_components[component_name].details_ui[detail_id][action_name] ;
+            const component = simhw_sim_components()[component_name];
+            const action = component?.details_ui?.[detail_id]?.[action_name];
+            return action ?? simcore_do_nothing_handler;
         }
 
         /**

--- a/sim_core/sim_core_ctrl.js
+++ b/sim_core/sim_core_ctrl.js
@@ -68,7 +68,7 @@
 	     var e = -1 ;
 	     for (var i=0; i<32; i++)
              {
-		  a = tri_mask & Math.pow(2, i) ;
+		  a = tri_mask & (1 << i) ;
                   if (a > 0) {
 	              e = i ;
 		      n = n + 1 ;
@@ -144,8 +144,9 @@
 
         function fn_updateL_now ( key )
         {
-	    update_draw(simhw_sim_signal(key), simhw_sim_signal(key).value) ;
-	    if ("L" == simhw_sim_signal(key).type) {
+		const signal = simhw_sim_signal(key);
+	    update_draw(signal, signal.value) ;
+	    if ("L" == signal.type) {
 		update_state(key) ;
 	    }
 	}
@@ -166,8 +167,9 @@
         function update_state ( key )
         {
            var index_behavior = 0;
-
-           switch (simhw_sim_signal(key).behavior.length)
+		   const signal = simhw_sim_signal(key);
+           const signal_length = signal.behavior.length;
+           switch (signal_length)
            {
                 case 0: // skip empty behavior
                      return;
@@ -178,8 +180,8 @@
                      break;
 
                 default:
-                     index_behavior = simhw_sim_signal(key).value ;
-                     if (simhw_sim_signal(key).behavior.length < index_behavior) {
+                     index_behavior = signal.value ;
+                     if (signal_length < index_behavior) {
                          ws_alert('ALERT: there are more signals values than behaviors defined!!!!\n' +
                                   'key: ' + key + ' and signal value: ' + index_behavior);
                          return;

--- a/sim_hw/hw_items/cpu_ep2.js
+++ b/sim_hw/hw_items/cpu_ep2.js
@@ -176,7 +176,6 @@ function cpu_ep2_register ( sim_p )
 
         sim_p.internal_states.FIRMWARE     = ws_empty_firmware ;
         sim_p.internal_states.io_hash      = {} ;
-        sim_p.internal_states.fire_stack   = [] ;
 
         sim_p.internal_states.tri_state_names = [ "T1","T2","T3","T4","T5","T6","T7","T8","T9","T10","T11","T12" ] ;
         sim_p.internal_states.fire_visible    = { 'databus': false, 'internalbus': false } ;
@@ -2575,23 +2574,23 @@ function cpu_ep2_register ( sim_p )
 					       types: ["S"],
 					   operation: function (s_expr)
 							{
+								const s_expr1 = s_expr[1];
+								const signal = sim_p.signals[s_expr1];
 							    // 0.- avoid loops
-							    if (sim_p.internal_states.fire_stack.indexOf(s_expr[1]) != -1) {
-								return ;
-							    }
-
-							    sim_p.internal_states.fire_stack.push(s_expr[1]) ;
+								if (signal.is_firing) {
+									return;
+								}
+								signal.is_firing = true;
 
 							    // 1.- update draw
-							    update_draw(sim_p.signals[s_expr[1]], sim_p.signals[s_expr[1]].value) ;
+							    update_draw(signal, signal.value) ;
 
 							    // 2.- for Level signals, propage it
-							    if ("L" ==  sim_p.signals[s_expr[1]].type)
+							    if ("L" ==  signal.type)
 							    {
-								update_state(s_expr[1]) ;
+								update_state(s_expr1) ;
 							    }
-
-							    sim_p.internal_states.fire_stack.pop(s_expr[1]) ;
+								signal.is_firing = false;
                                                         },
                                                 verbal: function (s_expr)
                                                         {
@@ -2683,17 +2682,16 @@ function cpu_ep2_register ( sim_p )
                                                             var new_mins = Object.create(get_value(mcelto));
                                                             sim_p.states["REG_MICROINS"].value = new_mins;
 
-                                                            // 4.- update signals
-							    var new_key_value = null ;
-							    for (var key in sim_p.signals)
-							    {
-							         new_key_value = new_mins[key] ;
-								 if (typeof new_key_value == "undefined") {
-							             new_key_value = sim_p.signals[key].default_value ;
-								 }
-
-								 set_value(sim_p.signals[key], new_key_value) ;
-							    }
+                                                             // 4.- update signals
+															for (const [key, signal] of Object.entries(sim_p.signals)) {
+																set_value(signal, signal.default_value);
+															}
+															for (const [key, value] of Object.entries(get_value(mcelto))) {
+																const signal = sim_p.signals[key];
+																if (signal) {
+																	set_value(signal, value);
+																}
+															}
 
                                                             // 5.- Finally, 'fire' the (High) Level signals
                                                             if (mcelto.is_native)


### PR DESCRIPTION
Several performance improvements. The changes in version ep2 can be backported to version ep. It is 2.08 times faster than the previous commit.
```bash
hyperfine -L dir "ws_dist,ws_dist_old" "./{dir}/wepsim.sh -a run -m ep2 -f ./{dir}/repo/microcode/mips/ep2_sig1_l10.mc -s ./{dir}/repo/assembly/mips/s4e3.asm --maxi 100000"
Benchmark 1: ./ws_dist/wepsim.sh -a run -m ep2 -f ./ws_dist/repo/microcode/mips/ep2_sig1_l10.mc -s ./ws_dist/repo/assembly/mips/s4e3.asm --maxi 100000
  Time (mean ± σ):      2.416 s ±  0.034 s    [User: 2.800 s, System: 0.055 s]
  Range (min … max):    2.385 s …  2.482 s    10 runs
 
Benchmark 2: ./ws_dist_old/wepsim.sh -a run -m ep2 -f ./ws_dist_old/repo/microcode/mips/ep2_sig1_l10.mc -s ./ws_dist_old/repo/assembly/mips/s4e3.asm --maxi 100000
  Time (mean ± σ):      5.032 s ±  0.071 s    [User: 5.388 s, System: 0.091 s]
  Range (min … max):    4.925 s …  5.120 s    10 runs
 
Summary
  ./ws_dist/wepsim.sh -a run -m ep2 -f ./ws_dist/repo/microcode/mips/ep2_sig1_l10.mc -s ./ws_dist/repo/assembly/mips/s4e3.asm --maxi 100000 ran
    2.08 ± 0.04 times faster than ./ws_dist_old/wepsim.sh -a run -m ep2 -f ./ws_dist_old/repo/microcode/mips/ep2_sig1_l10.mc -s ./ws_dist_old/repo/assembly/mips/s4e3.asm --maxi 100000
```