### PR TITLE
Precalcule order of E signals for performance

### DIFF
--- a/sim_hw/hw_items/cpu_ep.js
+++ b/sim_hw/hw_items/cpu_ep.js
@@ -2629,8 +2629,8 @@ function cpu_ep_register ( sim_p )
                                                             if ( (typeof mcelto !== "undefined") &&
                                                                  (false == mcelto.is_native) )
                                                             {
-                                                                for (var i=0; i<jit_fire_order.length; i++) {
-                                                                     fn_updateE_now(jit_fire_order[i]) ;
+																for (const key of jit_fire_order_E) {
+                                                                    update_state(key);
                                                                 }
                                                             }
 

--- a/sim_hw/hw_items/cpu_ep2.js
+++ b/sim_hw/hw_items/cpu_ep2.js
@@ -2586,8 +2586,8 @@ function cpu_ep2_register ( sim_p )
                                                             mcelto = sim_p.internal_states['MC'][new_maddr];
                                                             if ( (typeof mcelto !== "undefined") && (false == mcelto.is_native) )
                                                             {
-                                                                for (var i=0; i<jit_fire_order.length; i++) {
-                                                                     fn_updateE_now(jit_fire_order[i]) ;
+																for (const key of jit_fire_order_E) {
+                                                                    update_state(key);
                                                                 }
                                                             }
 

--- a/sim_hw/hw_items/cpu_poc.js
+++ b/sim_hw/hw_items/cpu_poc.js
@@ -2168,9 +2168,9 @@ function cpu_poc_register ( sim_p )
                                                             if ( (typeof mcelto !== "undefined") &&
                                                                  (false == mcelto.is_native) )
 							    {
-							        for (var i=0; i<jit_fire_order.length; i++) {
-								     fn_updateE_now(jit_fire_order[i]) ;
-							        }
+									for (const key of jit_fire_order_E) {
+										update_state(key);
+									}
 							    }
 
 							    // 3.- The (Falling) Edge part of the Control Unit...

--- a/sim_hw/hw_items/cpu_rv.js
+++ b/sim_hw/hw_items/cpu_rv.js
@@ -2681,8 +2681,8 @@ function cpu_rv_register ( sim_p )
                                                             if ( (typeof mcelto !== "undefined") &&
                                                                  (false == mcelto.is_native) )
                                                             {
-                                                                for (var i=0; i<jit_fire_order.length; i++) {
-                                                                     fn_updateE_now(jit_fire_order[i]) ;
+																for (const key of jit_fire_order_E) {
+                                                                    update_state(key);
                                                                 }
                                                             }
 

--- a/sim_hw/sim_hw_behavior.js
+++ b/sim_hw/sim_hw_behavior.js
@@ -99,6 +99,7 @@
         var jit_verbals     = false ;
         var jit_fire_dep    = null ;
         var jit_fire_order  = null ;
+        var jit_fire_order_E  = null ;
 	var jit_dep_network = null ;
         var jit_fire_ndep   = null ;
 
@@ -106,6 +107,7 @@
         {
             var allfireto = false;
             jit_fire_order = [];
+            jit_fire_order_E = [];
             jit_fire_ndep  = [];
             for (var sig in simhw_sim_signals())
             {
@@ -126,6 +128,12 @@
 		jit_fire_ndep[sig] = ndep;
                 if (allfireto == false)
                     jit_fire_order.push(sig);
+            }
+
+            for (var i=0; i<jit_fire_order.length; i++) {
+                if (simhw_sim_signal(jit_fire_order[i]).type == "E") {
+                    jit_fire_order_E.push(jit_fire_order[i]);
+                }
             }
         }
 


### PR DESCRIPTION
```bash
hyperfine --warmup 2 -r 5 -L dir "ws_dist,ws_dist_old" "./{dir}/wepsim.sh -a run -m ep2 -f ./{dir}/repo/microcode/rv32/ep2_sig1_l10.mc -s ./{dir}/repo/assembly/rv32/s4e3.asm --maxi 100000"
Benchmark 1: ./ws_dist/wepsim.sh -a run -m ep2 -f ./ws_dist/repo/microcode/rv32/ep2_sig1_l10.mc -s ./ws_dist/repo/assembly/rv32/s4e3.asm --maxi 100000
  Time (mean ± σ):      3.134 s ±  0.189 s    [User: 3.680 s, System: 0.097 s]
  Range (min … max):    2.970 s …  3.414 s    5 runs

Benchmark 2: ./ws_dist_old/wepsim.sh -a run -m ep2 -f ./ws_dist_old/repo/microcode/rv32/ep2_sig1_l10.mc -s ./ws_dist_old/repo/assembly/rv32/s4e3.asm --maxi 100000
  Time (mean ± σ):      3.469 s ±  0.108 s    [User: 3.986 s, System: 0.127 s]
  Range (min … max):    3.326 s …  3.573 s    5 runs

Summary
  ./ws_dist/wepsim.sh -a run -m ep2 -f ./ws_dist/repo/microcode/rv32/ep2_sig1_l10.mc -s ./ws_dist/repo/assembly/rv32/s4e3.asm --maxi 100000 ran
    1.11 ± 0.08 times faster than ./ws_dist_old/wepsim.sh -a run -m ep2 -f ./ws_dist_old/repo/microcode/rv32/ep2_sig1_l10.mc -s ./ws_dist_old/repo/assembly/rv32/s4e3.asm --maxi 100000
```
